### PR TITLE
Doesn't work <C-M> and <C-J>.

### DIFF
--- a/autoload/scratch.vim
+++ b/autoload/scratch.vim
@@ -168,7 +168,6 @@ function! s:initialize_scratch_buffer()  "{{{2
     $
   endif
 
-  silent! map <buffer> <unique> <CR>  <Plug>(scratch-evaluate)
   silent! map <buffer> <unique> <C-m>  <Plug>(scratch-evaluate)
   silent! map <buffer> <unique> <C-j>  <Plug>(scratch-evaluate)
 endfunction

--- a/autoload/scratch.vim
+++ b/autoload/scratch.vim
@@ -168,9 +168,9 @@ function! s:initialize_scratch_buffer()  "{{{2
     $
   endif
 
-  silent! map <buffer> <unique> <CR>  <Plug>scratch-evaluate
-  silent! map <buffer> <unique> <C-m>  <Plug>scratch-evaluate
-  silent! map <buffer> <unique> <C-j>  <Plug>scratch-evaluate
+  silent! map <buffer> <unique> <CR>  <Plug>(scratch-evaluate)
+  silent! map <buffer> <unique> <C-m>  <Plug>(scratch-evaluate)
+  silent! map <buffer> <unique> <C-j>  <Plug>(scratch-evaluate)
 endfunction
 
 


### PR DESCRIPTION
- kana/vim-scratch@315ca4ffb29aa90bf4a88b0e0124471145996cbb Fix mapping names.
- `<C-M>` and `<CR>` are the same.
